### PR TITLE
docs: add living repo-structure templates for website modernization

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,28 @@
+# AGENT.md – Arbeitsregeln (lebendes Dokument)
+
+Dieses Dokument definiert, wie am Repository gearbeitet wird.
+
+## 1) Grundprinzipien
+- Änderungen in kleinen, überprüfbaren Schritten.
+- Jede Strukturänderung muss in `Plan.md` reflektiert werden.
+- Keine sensiblen personenbezogenen Daten im Repository speichern.
+- Inhalte für die spätere Website verständlich und patientenfreundlich formulieren.
+
+## 2) Scope und Struktur
+- **Neue Produktentwicklung** findet unter `apps/`, `content/`, `docs/` statt.
+- **Historische Artefakte** bleiben unter `legacy/` getrennt.
+- Root-Dateien (`README.md`, `AGENT.md`, `Plan.md`) sind die primären Steuerdokumente.
+
+## 3) Qualitätsregeln
+- Dokumentationsänderungen immer mit klarer Motivation.
+- Keine „mysteriösen“ Dateien ohne Zweckbeschreibung.
+- Benennung konsistent und sprechend halten.
+
+## 4) Definition of Done (für Struktur-Tasks)
+Ein Struktur-Task gilt als fertig, wenn:
+1. Zielpfade klar definiert sind,
+2. README + Plan aktualisiert wurden,
+3. Legacy-Abgrenzung nachvollziehbar dokumentiert ist.
+
+## 5) Änderungslog (pflege dieses Dokument fortlaufend)
+- 2026-03-11: Initiale Version erstellt.

--- a/Plan.md
+++ b/Plan.md
@@ -1,0 +1,32 @@
+# Plan.md – Roadmap (lebendes Dokument)
+
+## Zielbild
+Aus dem aktuellen Repository einen klar strukturierten Ausgangspunkt für eine moderne Website zur Reflexintegration machen.
+
+## Phase 1 – Struktur klären (in Arbeit)
+- [x] Steuerdokumente anlegen (`README.md`, `AGENT.md`, `Plan.md`)
+- [ ] Zielordner real anlegen (`apps/`, `content/`, `docs/`, `legacy/`)
+- [ ] Legacy-Pfad für Talend festlegen und dokumentieren
+
+## Phase 2 – Legacy sauber abtrennen
+- [ ] `TMC_GIT/` nach `legacy/talend/TMC_GIT/` verschieben
+- [ ] Verweise/Erklärungen in README aktualisieren
+- [ ] Optional: Entscheidung treffen, ob Talend-Bestand in eigenes Archiv-Repo wandert
+
+## Phase 3 – Web-Fundament setzen
+- [ ] Ziel-Stack auswählen (Next.js/Astro/anderer)
+- [ ] Basisprojekt unter `apps/web/` initialisieren
+- [ ] Erste Seitenstruktur definieren (Start, Angebot, Über uns, Kontakt)
+
+## Phase 4 – Content- und Betriebsreife vorbereiten
+- [ ] Inhaltsmodelle für Leistungen/Themen/Kontakt in `content/` festlegen
+- [ ] Architektur- und Redaktionsleitfäden in `docs/` ergänzen
+- [ ] Qualitätschecks (Format/Lint/Build) einführen
+
+## Risiken / offene Entscheidungen
+- Welcher Web-Stack passt langfristig am besten?
+- Soll Legacy nur archiviert oder vollständig ausgelagert werden?
+- Welche Kontaktform (Formular/Telefon/E-Mail) ist rechtlich und organisatorisch sinnvoll?
+
+## Änderungslog
+- 2026-03-11: Initiale Roadmap erstellt.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# git-training-tmc
+# Reflexintegration Website – Projekt-README
+
+Dieses Repository wird von einem alten Talend-Projektstand auf eine moderne, wartbare Webprojekt-Struktur umgestellt.
+
+## Ziel
+Eine freundliche, vertrauensvolle Website für das Angebot zur Reflexintegration mit:
+- klaren Informationen zum Thema
+- Übersicht der Leistungen/Angebote
+- einfacher Kontaktmöglichkeit
+
+## Aktueller Stand (Ist)
+- Es existiert überwiegend ein historischer Talend-Bestand unter `TMC_GIT/`.
+- Eine moderne Web-App-Struktur ist noch nicht aufgebaut.
+
+## Zielstruktur (Soll)
+Die folgende Struktur ist der nächste sinnvolle Schritt für den Umbau:
+
+```text
+.
+├─ apps/
+│  └─ web/                  # spätere Website (z. B. Next.js/Astro/Vite)
+├─ content/
+│  ├─ angebote/
+│  ├─ themen/
+│  └─ kontakt/
+├─ docs/
+│  ├─ architecture.md
+│  ├─ content-guidelines.md
+│  └─ decisions/
+├─ legacy/
+│  └─ talend/
+│     └─ TMC_GIT/           # historischer Bestand (schrittweise entkoppeln)
+├─ AGENT.md                 # lebende Arbeitsregeln
+├─ Plan.md                  # lebende Roadmap
+└─ README.md
+```
+
+## Migrationsprinzip
+1. **Nicht mischen:** Neue Webentwicklung nicht im Legacy-Bereich starten.
+2. **Dokumentieren:** Jede Strukturentscheidung in `Plan.md` und `docs/decisions/` festhalten.
+3. **Kleine Schritte:** In kleinen Commits umbauen, damit Änderungen nachvollziehbar bleiben.
+
+## Nächster geplanter Umsetzungsschritt
+- Ordnerstruktur gemäß „Zielstruktur“ erstellen
+- Talend-Bestand nach `legacy/talend/` verschieben
+- Web-Stack-Entscheidung treffen (z. B. Next.js vs. Astro)
+- Basis-App unter `apps/web/` initialisieren
+
+## Hinweise für Mitarbeit
+- Arbeitsregeln: `AGENT.md`
+- Umsetzungspfad: `Plan.md`


### PR DESCRIPTION
## Summary
This PR creates the initial living documentation requested to modernize the repository structure as the first step toward a reflex integration website.

### Added
- `AGENT.md`
  - Working rules for contributors/agents
  - Scope boundaries between new development and legacy artifacts
  - Quality and Definition of Done for structure tasks
- `Plan.md`
  - Phase-based roadmap for repository restructuring and migration
  - Risks/open decisions and change log

### Updated
- `README.md`
  - Clear project goal and current-state assessment
  - Proposed modern target folder tree
  - Migration principles and immediate next steps

## Why
The repository currently contains legacy Talend artifacts and lacks a modern web-project structure and guidance documents. This PR establishes a shared foundation before implementing the technical migration.

## Next steps (follow-up)
1. Create the target directories (`apps/`, `content/`, `docs/`, `legacy/`).
2. Move `TMC_GIT/` under `legacy/talend/`.
3. Select and initialize the web stack under `apps/web/`.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b10f71dbd083239a52e4e575e1f84f)