### PR TITLE
docs: add AGENT.md policy baseline in repo root

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,39 @@
+# AGENT
+
+## 1) Arbeitsprinzipien
+- **Kleine PRs:** Änderungen in kleine, nachvollziehbare Pull Requests schneiden (ein klarer Zweck pro PR).
+- **Keine geheimen Daten:** Keine Secrets, Zugangsdaten, Tokens oder personenbezogenen Daten im Repository ablegen.
+- **Klare Commit-Messages:** Commit-Nachrichten präzise und handlungsorientiert formulieren (was/warum, nicht nur wie).
+
+## 2) Strukturregeln
+- **Neue Web-Dateien:** Neue Web-bezogene Dateien in die dafür vorgesehenen Web-Verzeichnisse legen (z. B. `web/`, `frontend/` oder vorhandene App-Struktur), nicht im Repo-Root verstreuen.
+- **Legacy-Inhalte:** Bestehende Legacy-Artefakte klar getrennt in dedizierten Legacy-Ordnern ablegen (z. B. `legacy/`), inklusive kurzer Einordnung im jeweiligen Ordner.
+
+## 3) Qualitäts-Gates
+Vor Merge müssen mindestens folgende Gates erfolgreich sein:
+- **Lint**
+- **Format**
+- **Build**
+- **Link-Check** (für Doku/Markdown)
+
+> Hinweis: Die konkreten Tools/Kommandos werden im nächsten Schritt je Technologie-Stack verbindlich festgelegt.
+
+## 4) Dokumentationspflichten
+Bei Strukturänderungen sind die zentralen Doku-Dateien mit zu aktualisieren:
+- **README** (aktuelle Struktur, Einstieg, relevante Pfade)
+- **PLAN** (Roadmap/Umsetzungsstand der Strukturmaßnahmen)
+
+## 5) Definition of Done (DoD) für Struktur-Tasks
+Ein Struktur-Task gilt als abgeschlossen, wenn:
+- die Zielstruktur umgesetzt und nachvollziehbar ist,
+- betroffene Pfade und Verantwortlichkeiten dokumentiert sind,
+- README/PLAN aktualisiert wurden,
+- alle definierten Qualitäts-Gates erfolgreich durchlaufen,
+- keine offenen Migrations- oder Ablagefragen unbeantwortet bleiben.
+
+## 6) Legacy/Talend: read-only oder migrieren?
+**Policy (klar und verbindlich):**
+- Legacy-/Talend-Inhalte sind standardmäßig **read-only**.
+- Änderungen an Legacy/Talend erfolgen nur im Rahmen eines explizit geplanten Migrations-Tasks.
+- Bei Migration gilt: schrittweise, nachvollziehbar, mit Mapping alt → neu und Rückverfolgbarkeit der Änderungen.
+- Ohne freigegebenen Migrationsplan: **keine inhaltlichen Änderungen** an Legacy/Talend-Artefakten.


### PR DESCRIPTION
### Motivation
- Provide a concise, repository-wide collaboration and structure policy covering working principles, file placement, quality gates, documentation duties and a Definition of Done for structural tasks.
- Make Legacy/Talend handling explicit by establishing a clear read-only-by-default rule and requiring planned migrations for any changes.

### Description
- Add new `AGENT.md` at the repository root containing six sections: 1) Arbeitsprinzipien, 2) Strukturregeln, 3) Qualitäts-Gates, 4) Dokumentationspflichten, 5) Definition of Done, and 6) Legacy/Talend policy.
- Specify minimal quality gates required before merge (`Lint`, `Format`, `Build`, `Link-Check`) and require updates to `README` and `PLAN` for structural changes.
- Define Legacy/Talend policy as read-only by default and require explicit, traceable migration plans for any modifications.

### Testing
- Verified the file `AGENT.md` exists at the repo root and its contents match the requested sections by printing the file with `nl -ba AGENT.md` (success).
- Confirmed the change was recorded in the repository state and a PR draft was prepared by the repository tooling (success).
- No stack-specific lint/build tests were executed because concrete tools/commands will be defined per technology in a follow-up step (not applicable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11032bbf48323ae3a34d0a0cab54c)